### PR TITLE
Adding Normalize() and Normalize2D() to Vector class

### DIFF
--- a/ppmod4.nut
+++ b/ppmod4.nut
@@ -311,6 +311,17 @@ try {
     return this.x + " " + this.y + " " + this.z;
   }
 
+  function Vector::Normalize() {
+    this.Norm();
+    return this;
+  }
+
+  function Vector::Normalize2D() {
+    this.z = 0.0;
+    this.Norm();
+    return this;
+  }
+
 } catch (e) {
 
   printl("[ppmod] Warning: failed to modify Vector class: " + e);


### PR DESCRIPTION
Two small utility methods that'll make some code that needs to be single-line more convenient, by returning this.
Won't override Norm() as it returns the length and that seems useful in some cases.

Ran these tests:
```js
(Vector(0.5, 0.7) / Vector(1, 1)).Normalize();  -> Vector(-nan, -nan, -nan); // shows why Normalize2D is necessary
(Vector(0.5, 0.7) / Vector(1, 1)).Normalize2D() -> Vector(0.581238, 0.813733, 0);
```